### PR TITLE
fix: improve health score calculation accuracy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-auditor-mcp",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "TypeScript/JavaScript code quality auditor with MCP server - Analyze code for SOLID principles, DRY violations, security patterns, and more",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "code-auditor-mcp",
-      "version": "1.17.1",
+      "version": "1.17.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -740,14 +740,31 @@ function getAllViolations(result: AuditResult): Violation[] {
 }
 
 function calculateHealthScore(result: AuditResult): number {
-  let score = 100;
-  const critical = result.summary.criticalIssues;
-  const warning = result.summary.warnings;
+  const filesAnalyzed = result.metadata?.filesAnalyzed || 1;
+  const critical = result.summary.criticalIssues || 0;
+  const warnings = result.summary.warnings || 0;
+  const suggestions = result.summary.suggestions || 0;
   
-  score -= critical * 10;
-  score -= warning * 2;
+  // Weight factors for different severity levels
+  const weights = {
+    critical: 10,
+    warning: 3,
+    suggestion: 0.5
+  };
   
-  return Math.max(0, Math.min(100, score));
+  // Calculate weighted violations per file
+  const weightedViolations = (critical * weights.critical) + 
+                             (warnings * weights.warning) + 
+                             (suggestions * weights.suggestion);
+  
+  const violationsPerFile = weightedViolations / filesAnalyzed;
+  
+  // Score calculation: 100 points minus deductions
+  // Each weighted violation per file reduces score
+  // Critical-heavy codebases drop faster than suggestion-heavy ones
+  let score = 100 - (violationsPerFile * 2);
+  
+  return Math.max(0, Math.round(Math.min(100, score)));
 }
 
 function generateRecommendations(result: AuditResult): any[] {


### PR DESCRIPTION
- Consider all severity levels (critical, warning, suggestions)
- Weight violations appropriately (10x, 3x, 0.5x)
- Normalize by files analyzed to handle different project sizes
- Calculate violations per file for fair comparison

Previous formula only considered critical and warnings, missing 95% of violations (suggestions) and didn't account for project size.
